### PR TITLE
Fix lint errors

### DIFF
--- a/internal/controller/proxy_controller.go
+++ b/internal/controller/proxy_controller.go
@@ -70,7 +70,7 @@ func (r *ProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	var tunnelList ktunnelsv1.TunnelList
 	if err := r.List(ctx, &tunnelList,
-		client.InNamespace(proxy.ObjectMeta.Namespace),
+		client.InNamespace(proxy.Namespace),
 		client.MatchingFields{proxyNameKey: proxy.Name},
 	); err != nil {
 		log.Error(err, "unable to fetch tunnels")


### PR DESCRIPTION
> QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)

> Error return value of `resp.Body.Close` is not checked (errcheck)
